### PR TITLE
Remove redundant oldName check in InitialHandler

### DIFF
--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
@@ -464,14 +464,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
         if ( isOnlineMode() )
         {
             // Check for multiple connections
-            // We have to check for the old name first
-            ProxiedPlayer oldName = bungee.getPlayer( getName() );
-            if ( oldName != null )
-            {
-                // TODO See #1218
-                oldName.disconnect( bungee.getTranslation( "already_connected_proxy" ) );
-            }
-            // And then also for their old UUID
+            // Check for their old UUID
             ProxiedPlayer oldID = bungee.getPlayer( getUniqueId() );
             if ( oldID != null )
             {


### PR DESCRIPTION
Since UUID is already checked, there is no reason to check for old name.